### PR TITLE
feat: add input doc generation helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,128 @@ did:peer:4zQmb7xLdVY9TXx8oov5XgpGUmGELgqiAV2699s43i6Qdm3M:zQSJgiFTYiCHjQ9MktwNTh
 >>> from did_peer_4 import resolve
 >>> document = resolve(did)
 >>> print(document)
-{'hello': 'world', 'alsoKnownAs': ['did:peer:4zQmb7xLdVY9TXx8oov5XgpGUmGELgqiAV2699s43i6Qdm3M'], 'id': 'did:peer:4zQmb7xLdVY9TXx8oov5XgpGUmGELgqiAV2699s43i6Qdm3M:zQSJgiFTYiCHjQ9MktwNThRXM7a'}
+{'hello': 'world', 'id': 'did:peer:4zQmb7xLdVY9TXx8oov5XgpGUmGELgqiAV2699s43i6Qdm3M:zQSJgiFTYiCHjQ9MktwNThRXM7a', 'alsoKnownAs': ['did:peer:4zQmb7xLdVY9TXx8oov5XgpGUmGELgqiAV2699s43i6Qdm3M']}
 >>> from did_peer_4 import resolve_short
 >>> short_document = resolve_short(did)
 >>> print(short_document)
-{'hello': 'world', 'alsoKnownAs': ['did:peer:4zQmb7xLdVY9TXx8oov5XgpGUmGELgqiAV2699s43i6Qdm3M:zQSJgiFTYiCHjQ9MktwNThRXM7a'], 'id': 'did:peer:4zQmb7xLdVY9TXx8oov5XgpGUmGELgqiAV2699s43i6Qdm3M'}
+{'hello': 'world', 'id': 'did:peer:4zQmb7xLdVY9TXx8oov5XgpGUmGELgqiAV2699s43i6Qdm3M', 'alsoKnownAs': ['did:peer:4zQmb7xLdVY9TXx8oov5XgpGUmGELgqiAV2699s43i6Qdm3M:zQSJgiFTYiCHjQ9MktwNThRXM7a']}
+
+```
+
+### With Input Document generation helper
+
+```python
+>>> import json
+>>> from did_peer_4 import encode, resolve
+>>> from did_peer_4.input_doc import input_doc_from_keys_and_services, KeySpec
+>>> key1 = KeySpec(
+...     multikey="z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+...     relationships=["authentication", "capabilityDelegation"],
+... )
+>>> key2 = KeySpec(
+...     multikey="z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+...     relationships=["keyAgreement"],
+... )
+>>> service = {
+...     "id": "#didcomm-0",
+...     "type": "DIDCommMessaging",
+...     "serviceEndpoint": {
+...         "uri": "didcomm:transport/queue",
+...         "accept": ["didcomm/v2"]
+...     }
+... }
+>>> input_doc = input_doc_from_keys_and_services([key1, key2], [service])
+>>> print(json.dumps(input_doc, indent=2))
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/multikey/v1"
+  ],
+  "verificationMethod": [
+    {
+      "id": "#key-0",
+      "type": "Multikey",
+      "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V"
+    },
+    {
+      "id": "#key-1",
+      "type": "Multikey",
+      "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc"
+    }
+  ],
+  "authentication": [
+    "#key-0"
+  ],
+  "capabilityDelegation": [
+    "#key-0"
+  ],
+  "service": [
+    {
+      "id": "#didcomm-0",
+      "type": "DIDCommMessaging",
+      "serviceEndpoint": {
+        "uri": "didcomm:transport/queue",
+        "accept": [
+          "didcomm/v2"
+        ]
+      }
+    }
+  ],
+  "keyAgreement": [
+    "#key-1"
+  ]
+}
+>>> did = encode(input_doc)
+>>> print(did)
+did:peer:4zQmQabhRUiFPAmn7CX6B8V6qmfrs7nQQyFb6zAD7EAWvW3c:zMoDtDfb4quiz6yXy8ftBst291RGXBJaVy8FMivQWVLPbYUSAS68WgeWNxtdR5aBNraMHsPZi4iSWizFpbbZxQ2Cw56HwPxwG3SMa3wCtUkRj1LrAjcC1EE11t7vq1mggN2Y5xHTJpEbCLNnrUHG99RBb7fDEJff2YzCFqKxW4NU6tdjtw5fEy6Kz5f3KzeybV74aZY8QwWFMi3j9brksFsNhhCWyk65tKgaE2b5qyD6tLF5u3rNuEAUGNTTaJ1hPGKgCZaAAm4TdjuaSXoVaSxiXXkWjEsxRnLnqeNbw6djogDw41v2tpEawTQX7ZqL5ZbYzPi6N6L2e9Kkf4i2K2WMVLTW41n6AGmDguJPqrgkpCb71v2WiMGSsQPzk5EyPucdfQmxyn7tj4E21nZGNfY415Sp2XQZZ7yQPAimq3WrYf54srZfVjXvJBrMosCPDdm5bVKitRLjmh8ueQ3Pa8CcT3zHy8RtQRuKTQgKyWLUvMitN1eQEtaRo1vLNLYEX4cXhG51haarXRfEFyCr3FZeE9oBRWkZioCrkZTEL8rz4GAAnpPojxCPXsecE1WJXkcqZw1bS9YwU5gugNybPAFpoc2AhwtcQNvj9UhaZisVvPiEsynRG2cmwyjqi5dD8b6FvwCMUq8FzkpyV2UR8ePMMt3Co8FofVvKCkU4a4CRWF6hWCrEQqpSC5abNscuvpcMUfzvSVNrFVZyCiSMX2Wwa7tnxvujZTjutKXr
+>>> document = resolve_short(did)
+>>> print(json.dumps(document, indent=2))
+{
+  "@context": [
+    "https://www.w3.org/ns/did/v1",
+    "https://w3id.org/security/multikey/v1"
+  ],
+  "verificationMethod": [
+    {
+      "id": "#key-0",
+      "type": "Multikey",
+      "publicKeyMultibase": "z6MkqRYqQiSgvZQdnBytw86Qbs2ZWUkGv22od935YF4s8M7V",
+      "controller": "did:peer:4zQmQabhRUiFPAmn7CX6B8V6qmfrs7nQQyFb6zAD7EAWvW3c"
+    },
+    {
+      "id": "#key-1",
+      "type": "Multikey",
+      "publicKeyMultibase": "z6LSbysY2xFMRpGMhb7tFTLMpeuPRaqaWM1yECx2AtzE3KCc",
+      "controller": "did:peer:4zQmQabhRUiFPAmn7CX6B8V6qmfrs7nQQyFb6zAD7EAWvW3c"
+    }
+  ],
+  "authentication": [
+    "#key-0"
+  ],
+  "capabilityDelegation": [
+    "#key-0"
+  ],
+  "service": [
+    {
+      "id": "#didcomm-0",
+      "type": "DIDCommMessaging",
+      "serviceEndpoint": {
+        "uri": "didcomm:transport/queue",
+        "accept": [
+          "didcomm/v2"
+        ]
+      }
+    }
+  ],
+  "keyAgreement": [
+    "#key-1"
+  ],
+  "id": "did:peer:4zQmQabhRUiFPAmn7CX6B8V6qmfrs7nQQyFb6zAD7EAWvW3c",
+  "alsoKnownAs": [
+    "did:peer:4zQmQabhRUiFPAmn7CX6B8V6qmfrs7nQQyFb6zAD7EAWvW3c:zMoDtDfb4quiz6yXy8ftBst291RGXBJaVy8FMivQWVLPbYUSAS68WgeWNxtdR5aBNraMHsPZi4iSWizFpbbZxQ2Cw56HwPxwG3SMa3wCtUkRj1LrAjcC1EE11t7vq1mggN2Y5xHTJpEbCLNnrUHG99RBb7fDEJff2YzCFqKxW4NU6tdjtw5fEy6Kz5f3KzeybV74aZY8QwWFMi3j9brksFsNhhCWyk65tKgaE2b5qyD6tLF5u3rNuEAUGNTTaJ1hPGKgCZaAAm4TdjuaSXoVaSxiXXkWjEsxRnLnqeNbw6djogDw41v2tpEawTQX7ZqL5ZbYzPi6N6L2e9Kkf4i2K2WMVLTW41n6AGmDguJPqrgkpCb71v2WiMGSsQPzk5EyPucdfQmxyn7tj4E21nZGNfY415Sp2XQZZ7yQPAimq3WrYf54srZfVjXvJBrMosCPDdm5bVKitRLjmh8ueQ3Pa8CcT3zHy8RtQRuKTQgKyWLUvMitN1eQEtaRo1vLNLYEX4cXhG51haarXRfEFyCr3FZeE9oBRWkZioCrkZTEL8rz4GAAnpPojxCPXsecE1WJXkcqZw1bS9YwU5gugNybPAFpoc2AhwtcQNvj9UhaZisVvPiEsynRG2cmwyjqi5dD8b6FvwCMUq8FzkpyV2UR8ePMMt3Co8FofVvKCkU4a4CRWF6hWCrEQqpSC5abNscuvpcMUfzvSVNrFVZyCiSMX2Wwa7tnxvujZTjutKXr"
+  ]
+}
+
 ```
 
 ## Tutorial

--- a/did_peer_4/input_doc.py
+++ b/did_peer_4/input_doc.py
@@ -1,0 +1,58 @@
+"""Helpers for creating input documents for the DID method."""
+from dataclasses import dataclass
+from typing import Any, Dict, Literal, Optional, Sequence
+
+RELATIONSHIPS = (
+    "authentication",
+    "assertionMethod",
+    "keyAgreement",
+    "capabilityDelegation",
+    "capabilityInvocation",
+)
+
+Relationship = Literal[
+    "authentication",
+    "assertionMethod",
+    "keyAgreement",
+    "capabilityDelegation",
+    "capabilityInvocation",
+]
+
+
+@dataclass
+class KeySpec:
+    """Key specification."""
+
+    multikey: str
+    relationships: Sequence[Relationship]
+
+
+def input_doc_from_keys_and_services(
+    keys: Sequence[KeySpec], services: Optional[Sequence[dict]] = None
+) -> dict:
+    """Create an input document for a set of keys and services."""
+    input_doc: Dict[str, Any] = {
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/multikey/v1",
+        ]
+    }
+    for index, key in enumerate(keys):
+        ident = f"#key-{index}"
+        input_doc.setdefault("verificationMethod", []).append(
+            {
+                "id": ident,
+                "type": "Multikey",
+                "publicKeyMultibase": key.multikey,
+            }
+        )
+        for relationship in key.relationships:
+            if relationship not in RELATIONSHIPS:
+                raise ValueError(f"Invalid relationship: {relationship}")
+
+            input_doc.setdefault(relationship, []).append(ident)
+
+        if services:
+            input_doc["service"] = services
+
+    return input_doc

--- a/pdm.lock
+++ b/pdm.lock
@@ -3,10 +3,9 @@
 
 [metadata]
 groups = ["default", "dev"]
-cross_platform = true
-static_urls = false
-lock_version = "4.3"
-content_hash = "sha256:7c643a5b6447c95d53c76512366204499939a680a0dc286855adc438ecf68a4f"
+strategy = ["cross_platform"]
+lock_version = "4.4"
+content_hash = "sha256:3fcb8fdfe293a010ab2f8aff60ea88247a3b15a9a7c137dd2c8383fb24daa0cf"
 
 [[package]]
 name = "base58"
@@ -349,6 +348,19 @@ dependencies = [
 files = [
     {file = "pytest-cov-4.1.0.tar.gz", hash = "sha256:3904b13dfbfec47f003b8e77fd5b589cd11904a21ddf1ab38a64f204d6a10ef6"},
     {file = "pytest_cov-4.1.0-py3-none-any.whl", hash = "sha256:6ba70b9e97e69fcc3fb45bfeab2d0a138fb65c4d0d6a41ef33983ad114be8c3a"},
+]
+
+[[package]]
+name = "pytest-ruff"
+version = "0.2.1"
+requires_python = ">=3.7,<4.0"
+summary = "pytest plugin to check ruff requirements."
+dependencies = [
+    "ruff>=0.0.242",
+]
+files = [
+    {file = "pytest_ruff-0.2.1-py3-none-any.whl", hash = "sha256:f586bbd7978cb5782b673c8e55fa069d83430139931b918bd72232ba3f71eb67"},
+    {file = "pytest_ruff-0.2.1.tar.gz", hash = "sha256:078ad696bfa347b466991ed4f9cc5ec807f5a171d7f06091660d8f16ba03a5dc"},
 ]
 
 [[package]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dev = [
     "ruff>=0.0.285",
     "pre-commit>=3.3.3",
     "pytest-cov>=4.1.0",
+    "pytest-ruff>=0.2.1",
 ]
 
 [tool.coverage.report]
@@ -33,3 +34,9 @@ exclude_lines = [
 precision = 2
 skip_covered = true
 show_missing = true
+
+[tool.pytest.ini_options]
+addopts = """
+    --cov=did_peer_4 --cov-report=term-missing --cov-branch --cov-fail-under=85 --cov-context=test
+    --doctest-glob README.md --ruff
+"""

--- a/tests/test_did_peer_4.py
+++ b/tests/test_did_peer_4.py
@@ -1,6 +1,14 @@
 import json
 
-from did_peer_4 import decode, encode, long_to_short, resolve, resolve_short
+from did_peer_4 import (
+    decode,
+    encode,
+    encode_short,
+    long_to_short,
+    resolve,
+    resolve_short,
+    resolve_short_from_doc,
+)
 
 
 DOC = {
@@ -41,12 +49,15 @@ DOC = {
 
 
 def test_encode_decode():
+    encoded = encode(DOC, validate=False)
     encoded = encode(DOC)
     print()
     print(encoded)
     print(long_to_short(encoded))
     decoded = decode(encoded)
     assert decoded == DOC
+    assert encode_short(DOC) == long_to_short(encoded)
+    assert resolve_short_from_doc(DOC, long_to_short(encoded)) == resolve_short(encoded)
 
 
 def test_resolve():

--- a/tests/test_input_doc.py
+++ b/tests/test_input_doc.py
@@ -1,0 +1,64 @@
+from did_peer_4 import encode
+from did_peer_4.input_doc import input_doc_from_keys_and_services, KeySpec
+from did_peer_4.valid import validate_input_document
+
+ED25519_MULTIKEY = "z6MkrCD1csqtgdj8sjrsu8jxcbeyP6m7LiK87NzhfWqio5yr"
+X25519_MULTIKEY = "z6LSqPZfn9krvgXma2icTMKf2uVcYhKXsudCmPoUzqGYW24U"
+
+
+def test_input_doc_generation():
+    input_doc = input_doc_from_keys_and_services(
+        [
+            KeySpec(
+                multikey=ED25519_MULTIKEY,
+                relationships=["authentication"],
+            ),
+            KeySpec(
+                multikey=X25519_MULTIKEY,
+                relationships=["keyAgreement"],
+            ),
+        ],
+        [
+            {
+                "id": "#didcommmessaging-0",
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                    "uri": "didcomm:transport/queue",
+                    "accept": ["didcomm/v2"],
+                },
+            }
+        ],
+    )
+
+    assert input_doc == {
+        "@context": [
+            "https://www.w3.org/ns/did/v1",
+            "https://w3id.org/security/multikey/v1",
+        ],
+        "verificationMethod": [
+            {
+                "id": "#key-0",
+                "type": "Multikey",
+                "publicKeyMultibase": ED25519_MULTIKEY,
+            },
+            {
+                "id": "#key-1",
+                "type": "Multikey",
+                "publicKeyMultibase": X25519_MULTIKEY,
+            },
+        ],
+        "authentication": ["#key-0"],
+        "keyAgreement": ["#key-1"],
+        "service": [
+            {
+                "id": "#didcommmessaging-0",
+                "type": "DIDCommMessaging",
+                "serviceEndpoint": {
+                    "uri": "didcomm:transport/queue",
+                    "accept": ["didcomm/v2"],
+                },
+            }
+        ],
+    }
+    assert validate_input_document(input_doc)
+    assert encode(input_doc)


### PR DESCRIPTION
This adds an optional helper for generating an input document from a set of keys and services. This helper is intentionally simple; it won't cover all use cases. But when all you need is a basic document, it will get you there without having to worry about contexts and such.

Additionally, those familiar with the did-peer-2 library will see similarities between the helper added here and the `generate` method in the did-peer-2 library. This is deliberate and should hopefully help ease the transition for those adopting did:peer:4 after did:peer:2.

I accidentally made the generation of did:peer:2 actually pretty okay, interface wise. This addition seeks to prevent that from becoming a barrier to adoption.